### PR TITLE
Add google site verification meta and dns record

### DIFF
--- a/GOOGLE_VERIFICATION_SETUP.md
+++ b/GOOGLE_VERIFICATION_SETUP.md
@@ -1,0 +1,72 @@
+# Google Site Verification Setup
+
+## การตั้งค่าการยืนยันเว็บไซต์กับ Google
+
+### 1. Meta Tag Verification (ติดตั้งแล้ว ✅)
+เมตาแท็กสำหรับการยืนยันได้ถูกเพิ่มในไฟล์ `index.html` แล้ว:
+```html
+<meta name="google-site-verification" content="X8vvOgzWB2UFcwWtd04rBJbmF6SjF2btzESxiJhY2Oc" />
+```
+
+### 2. Google Analytics Setup (ติดตั้งแล้ว ✅)
+โค้ด Google Analytics (gtag.js) ได้ถูกเพิ่มในส่วน `<head>` ของ `index.html` แล้ว
+
+**หมายเหตุสำคัญ:** คุณต้องแทนที่ `G-XXXXXXXXXX` ด้วย Measurement ID จริงของคุณจาก Google Analytics
+
+ขั้นตอนการหา Measurement ID:
+1. เข้าสู่ระบบ Google Analytics
+2. ไปที่ Admin (การตั้งค่า)
+3. เลือก Property ของคุณ
+4. ไปที่ Data Streams
+5. คลิกที่ Web stream ของคุณ
+6. คัดลอก Measurement ID (เริ่มต้นด้วย G-)
+
+### 3. DNS TXT Record Configuration
+
+สำหรับการยืนยันผ่าน DNS, คุณต้องเพิ่ม TXT record ในการตั้งค่า DNS ของโดเมน `cgunxl.github.io`
+
+#### ข้อมูล TXT Record:
+- **Type:** TXT
+- **Name/Host:** @ (หรือเว้นว่างสำหรับ root domain)
+- **Value:** `google-site-verification=z9Hgi939tRB43Bu33YrYjttulyTiP8biwjIeyJgd47M`
+- **TTL:** 3600 (หรือค่าเริ่มต้น)
+
+#### ขั้นตอนการเพิ่ม TXT Record:
+
+##### สำหรับ GitHub Pages (cgunxl.github.io):
+หมายเหตุ: GitHub Pages ไม่รองรับการเพิ่ม TXT records โดยตรง คุณมีตัวเลือกดังนี้:
+
+1. **ใช้ Meta Tag Verification (แนะนำ)** - ซึ่งได้ติดตั้งแล้วในไฟล์ index.html
+2. **ใช้ Custom Domain** - หากคุณมีโดเมนของตัวเอง คุณสามารถเพิ่ม TXT record ที่ DNS provider ของคุณ
+
+##### สำหรับ Custom Domain (ถ้ามี):
+1. เข้าสู่ระบบที่ผู้ให้บริการโดเมนของคุณ (เช่น GoDaddy, Namecheap, Cloudflare)
+2. ไปที่หน้า DNS Management หรือ DNS Settings
+3. เพิ่ม TXT Record ใหม่ด้วยข้อมูลด้านบน
+4. บันทึกการเปลี่ยนแปลง
+5. รอ 5-10 นาทีเพื่อให้ DNS propagate
+6. กลับไปที่ Google Search Console เพื่อยืนยัน
+
+### 4. การตรวจสอบการติดตั้ง
+
+#### ตรวจสอบ Meta Tag:
+1. เปิดเว็บไซต์ของคุณ
+2. คลิกขวาและเลือก "View Page Source"
+3. ค้นหา "google-site-verification" ในโค้ด HTML
+
+#### ตรวจสอบ Google Analytics:
+1. เปิด Google Analytics Real-Time reports
+2. เข้าเว็บไซต์ของคุณในแท็บอื่น
+3. ตรวจสอบว่ามีการแสดงผู้ใช้งานใน Real-Time reports
+
+### 5. สิ่งที่ต้องทำต่อไป
+
+- [ ] แทนที่ `G-XXXXXXXXXX` ในไฟล์ `index.html` ด้วย Measurement ID จริงของคุณ
+- [ ] ยืนยันเว็บไซต์ใน Google Search Console
+- [ ] ตั้งค่า Google Analytics Goals และ Events ตามต้องการ
+- [ ] ส่ง sitemap.xml ไปยัง Google Search Console
+
+### ลิงก์ที่เป็นประโยชน์
+- [Google Search Console](https://search.google.com/search-console)
+- [Google Analytics](https://analytics.google.com)
+- [Google Site Verification Methods](https://support.google.com/webmasters/answer/9008080)

--- a/index.html
+++ b/index.html
@@ -6,6 +6,18 @@
     <title>BwnX - Platform แนะนำสิ่งที่ดีที่สุดในการใช้ชีวิต</title>
     <meta name="description" content="BwnX - Platform การให้คำแนะนำสิ่งที่คุณต้องการที่ดีที่สุดในการใช้ชีวิต หาเงิน และไลฟ์สไตล์">
     
+    <!-- Google Site Verification -->
+    <meta name="google-site-verification" content="X8vvOgzWB2UFcwWtd04rBJbmF6SjF2btzESxiJhY2Oc" />
+    
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-XXXXXXXXXX');
+    </script>
+    
     <!-- Alternate language links for SEO -->
     <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
     <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />


### PR DESCRIPTION
Add Google Search Console verification meta tag and Google Analytics tracking code to `index.html` and provide setup documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc685b5c-0f04-4481-ad63-d6d0feecfc08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc685b5c-0f04-4481-ad63-d6d0feecfc08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

