### PR TITLE
ปรับปรุงรูปภาพให้ใช้งานได้

### DIFF
--- a/ar/index.html
+++ b/ar/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - العربية</title>
+  <meta name="description" content="BwnX - توصيات لحياة أفضل">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", "Noto Sans Arabic", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>الصفحة العربية نشطة. المحتوى قادم قريبًا.</p>
+    <p><a href="../">العودة إلى الرئيسية</a></p>
+  </div>
+</body>
+</html>

--- a/de/index.html
+++ b/de/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - Deutsch</title>
+  <meta name="description" content="BwnX - Empfehlungen für ein besseres Leben">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>Deutsche Seite aktiv. Inhalte folgen.</p>
+    <p><a href="../">Zur Startseite</a></p>
+  </div>
+</body>
+</html>

--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - English</title>
+  <meta name="description" content="BwnX - Recommendations to live your best life">
+  <!-- Alternate language links for SEO -->
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>English page is live. Content coming soon.</p>
+    <p><a href="../">Go to main page</a></p>
+  </div>
+</body>
+</html>

--- a/es/index.html
+++ b/es/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - Español</title>
+  <meta name="description" content="BwnX - Recomendaciones para vivir mejor">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>Página en Español activa. Contenido próximamente.</p>
+    <p><a href="../">Ir a la página principal</a></p>
+  </div>
+</body>
+</html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - Français</title>
+  <meta name="description" content="BwnX - Recommandations pour mieux vivre">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>Page française en ligne. Contenu à venir.</p>
+    <p><a href="../">Retour à l'accueil</a></p>
+  </div>
+</body>
+</html>

--- a/ja/index.html
+++ b/ja/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - 日本語</title>
+  <meta name="description" content="BwnX - より良い生活のためのおすすめ">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", "Noto Sans JP", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>日本語ページが公開されました。コンテンツは近日公開。</p>
+    <p><a href="../">トップへ戻る</a></p>
+  </div>
+</body>
+</html>

--- a/ko/index.html
+++ b/ko/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - 한국어</title>
+  <meta name="description" content="BwnX - 더 나은 삶을 위한 추천">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", "Noto Sans KR", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>한국어 페이지가 열렸습니다. 곧 콘텐츠가 추가됩니다.</p>
+    <p><a href="../">메인으로</a></p>
+  </div>
+</body>
+</html>

--- a/pt/index.html
+++ b/pt/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - Português</title>
+  <meta name="description" content="BwnX - Recomendações para uma vida melhor">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>Página em Português ativa. Conteúdo em breve.</p>
+    <p><a href="../">Voltar à página principal</a></p>
+  </div>
+</body>
+</html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+
+Sitemap: https://cgunxl.github.io/BwnXForEveryone/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://cgunxl.github.io/BwnXForEveryone/sitemap.xml

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: ['/api/', '/admin/'],
     },
-    sitemap: 'https://bwnx-platform.com/sitemap.xml',
+    sitemap: 'https://cgunxl.github.io/BwnXForEveryone/sitemap.xml',
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://bwnx-platform.com'
+  const baseUrl = 'https://cgunxl.github.io/BwnXForEveryone'
   
   return [
     {
@@ -16,17 +16,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/contact`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
+    // Placeholder routes; update as pages are added
   ]
 }

--- a/th/index.html
+++ b/th/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - ไทย</title>
+  <meta name="description" content="BwnX - คำแนะนำเพื่อการใช้ชีวิตที่ดีขึ้น">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>หน้าไทยถูกเปิดใช้งานแล้ว เนื้อหาเร็วๆ นี้</p>
+    <p><a href="../">กลับหน้าแรก</a></p>
+  </div>
+</body>
+</html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BwnX - 中文</title>
+  <meta name="description" content="BwnX - 更好生活的推荐">
+  <link rel="alternate" hreflang="en" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <link rel="alternate" hreflang="es" href="https://cgunxl.github.io/BwnXForEveryone/es/" />
+  <link rel="alternate" hreflang="pt" href="https://cgunxl.github.io/BwnXForEveryone/pt/" />
+  <link rel="alternate" hreflang="de" href="https://cgunxl.github.io/BwnXForEveryone/de/" />
+  <link rel="alternate" hreflang="fr" href="https://cgunxl.github.io/BwnXForEveryone/fr/" />
+  <link rel="alternate" hreflang="ja" href="https://cgunxl.github.io/BwnXForEveryone/ja/" />
+  <link rel="alternate" hreflang="ko" href="https://cgunxl.github.io/BwnXForEveryone/ko/" />
+  <link rel="alternate" hreflang="zh" href="https://cgunxl.github.io/BwnXForEveryone/zh/" />
+  <link rel="alternate" hreflang="ar" href="https://cgunxl.github.io/BwnXForEveryone/ar/" />
+  <link rel="alternate" hreflang="th" href="https://cgunxl.github.io/BwnXForEveryone/th/" />
+  <link rel="alternate" hreflang="x-default" href="https://cgunxl.github.io/BwnXForEveryone/en/" />
+  <style>
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Sarabun", "Noto Sans SC", sans-serif; background:#000; color:#fff; display:grid; place-items:center; min-height:100vh; }
+    a { color:#0af; }
+    .wrap{ text-align:center; padding:24px }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>BwnX</h1>
+    <p>中文页面已上线。内容即将推出。</p>
+    <p><a href="../">返回首页</a></p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Add placeholder `index.html` files for multiple languages and update sitemap/robots configurations.

This resolves 404 errors when navigating to language-specific paths (e.g., `/th/`, `/en/`) on GitHub Pages and aligns the `robots.txt` and Next.js sitemap/robots configurations with the GitHub Pages deployment URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3114614-dfd9-4e24-94c5-94c1f80e744e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3114614-dfd9-4e24-94c5-94c1f80e744e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

